### PR TITLE
Include first user prompt in embedding context

### DIFF
--- a/GptCategorize/__init__.py
+++ b/GptCategorize/__init__.py
@@ -1,8 +1,8 @@
 """
-GptCategorize package for categorizing ChatGPT chats by title.
+GptCategorize package for categorizing ChatGPT chats by title and initial prompt.
 
 This package provides functionality to analyze ChatGPT conversation exports,
-cluster similar chats by title using embeddings and machine learning,
+cluster similar chats by title and the first user prompt using embeddings and machine learning,
 and generate provisional move plans for organizing chats into project folders.
 """
 

--- a/debug_config.py
+++ b/debug_config.py
@@ -13,10 +13,7 @@ from typing import Type
 
 
 def start_debug_server(
-    host: str = "localhost",
-    port: int = 5678,
-    wait_for_client: bool = False,
-    log_to_stderr: bool = False
+    host: str = "localhost", port: int = 5678, wait_for_client: bool = False, log_to_stderr: bool = False
 ) -> None:
     """
     Start the debugpy debug server.
@@ -52,9 +49,7 @@ def enable_debugging_on_exception() -> None:
     """
 
     def excepthook(
-        exc_type: Type[BaseException],
-        exc_value: BaseException,
-        exc_traceback: TracebackType | None
+        exc_type: Type[BaseException], exc_value: BaseException, exc_traceback: TracebackType | None
     ) -> None:
         if exc_type is KeyboardInterrupt:
             # Don't debug keyboard interrupts
@@ -112,10 +107,10 @@ def auto_start_if_enabled() -> None:
         DEBUGPY_PORT: Port to bind to (default: 5678)
         DEBUGPY_WAIT: Set to '1', 'true', 'yes' to wait for client
     """
-    if os.environ.get('DEBUGPY_ENABLE', '').lower() in ('1', 'true', 'yes'):
-        host = os.environ.get('DEBUGPY_HOST', 'localhost')
-        port = int(os.environ.get('DEBUGPY_PORT', '5678'))
-        wait = os.environ.get('DEBUGPY_WAIT', '').lower() in ('1', 'true', 'yes')
+    if os.environ.get("DEBUGPY_ENABLE", "").lower() in ("1", "true", "yes"):
+        host = os.environ.get("DEBUGPY_HOST", "localhost")
+        port = int(os.environ.get("DEBUGPY_PORT", "5678"))
+        wait = os.environ.get("DEBUGPY_WAIT", "").lower() in ("1", "true", "yes")
 
         start_debug_server(host=host, port=port, wait_for_client=wait)
 
@@ -136,16 +131,12 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    start_debug_server(
-        host=args.host,
-        port=args.port,
-        wait_for_client=args.wait,
-        log_to_stderr=args.log
-    )
+    start_debug_server(host=args.host, port=args.port, wait_for_client=args.wait, log_to_stderr=args.log)
 
     print("Debug server running. Press Ctrl+C to stop.")
     try:
         import time
+
         while True:
             time.sleep(1)
     except KeyboardInterrupt:

--- a/main.py
+++ b/main.py
@@ -9,9 +9,10 @@ What this program does
    - Export your data from ChatGPT, unzip it yourself, then pass the path to a
      JSON file that contains the conversation objects (commonly `conversations.json`).
 2) Skips any chats already assigned to a project/workspace/folder.
-3) Creates embeddings for titles with **text-embedding-3-large** (using a dedicated
+3) Creates embeddings for each chat's title plus the first 250 words of the
+   initial user prompt using **text-embedding-3-large** (via a dedicated
    Embeddings API base/key), and optionally persists vectors into local **Qdrant**.
-4) Clusters titles (DBSCAN over L2-normalized embeddings ≈ cosine distance),
+4) Clusters chats (DBSCAN over L2-normalized embeddings ≈ cosine distance),
    falling back to KMeans if DBSCAN yields nothing useful.
 5) Uses **gpt-5-mini** (via a separate Inference API base/key) to label clusters
    and propose project folder slugs.


### PR DESCRIPTION
## Summary
- Extract the first user prompt from each conversation and store a 250-word excerpt.
- Embed both the chat title and prompt excerpt to improve clustering cohesion.
- Persist prompt excerpts alongside embeddings and update docs to reflect the added context.

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68c5c7f47de0832d8d2ab46e686324c2