### PR TITLE
Add initial pytest suite with coverage and parallel plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ format:
 # Run tests (if any are added later)
 .PHONY: test
 test:
-	$(PYTHON) -m pytest -v
+        $(PYTHON) -m pytest -n auto --cov=GptCategorize --cov=main --cov-report=term-missing -v
 
 # Check if virtual environment exists
 .PHONY: check-venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ dev = [
     "flake8>=7.3.0",
     "mypy>=1.18.1",
     "pytest>=8.4.2",
+    "pytest-cov>=5.0.0",
+    "pytest-xdist>=3.6.1",
     "types-tqdm>=4.67.0.20250809",
     "debugpy>=1.8.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,143 @@
+"""Test configuration for the gpt-organizer project.
+
+This module installs light-weight stubs for optional third party
+integrations so that unit tests can import ``GptCategorize.categorize``
+without requiring the real ``openai`` and ``qdrant_client`` packages to
+be installed in the execution environment.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _ensure_openai_stub() -> None:
+    if "openai" in sys.modules:
+        return
+
+    openai_stub = types.ModuleType("openai")
+
+    class _OpenAI:  # pragma: no cover - trivial container
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401
+            """Minimal stub that accepts arbitrary arguments."""
+
+    openai_stub.OpenAI = _OpenAI
+    sys.modules["openai"] = openai_stub
+
+
+def _ensure_qdrant_stub() -> None:
+    if "qdrant_client" in sys.modules:
+        return
+
+    qdrant_stub = types.ModuleType("qdrant_client")
+
+    class _QdrantClient:  # pragma: no cover - trivial container
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401
+            """Minimal stub that accepts arbitrary arguments."""
+
+    qdrant_stub.QdrantClient = _QdrantClient
+
+    http_stub = types.ModuleType("qdrant_client.http")
+    models_stub = types.ModuleType("qdrant_client.http.models")
+
+    class _Distance:  # pragma: no cover - trivial container
+        COSINE = "cosine"
+
+    class _VectorParams:  # pragma: no cover - trivial container
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401
+            """Minimal stub that accepts arbitrary arguments."""
+
+    class _PointStruct:  # pragma: no cover - trivial container
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401
+            """Minimal stub that accepts arbitrary arguments."""
+
+    models_stub.Distance = _Distance
+    models_stub.VectorParams = _VectorParams
+    models_stub.PointStruct = _PointStruct
+
+    http_stub.models = models_stub
+
+    qdrant_stub.http = http_stub
+
+    sys.modules["qdrant_client"] = qdrant_stub
+    sys.modules["qdrant_client.http"] = http_stub
+    sys.modules["qdrant_client.http.models"] = models_stub
+
+
+def _ensure_tqdm_stub() -> None:
+    if "tqdm" in sys.modules:
+        return
+
+    tqdm_stub = types.ModuleType("tqdm")
+
+    def _tqdm(iterable=None, *args, **kwargs):  # pragma: no cover - trivial container
+        return iterable
+
+    tqdm_stub.tqdm = _tqdm
+    sys.modules["tqdm"] = tqdm_stub
+
+
+def _ensure_sklearn_stub() -> None:
+    if "sklearn" in sys.modules:
+        return
+
+    sklearn_stub = types.ModuleType("sklearn")
+    cluster_stub = types.ModuleType("sklearn.cluster")
+    preprocessing_stub = types.ModuleType("sklearn.preprocessing")
+
+    import numpy as _np
+
+    class _DBSCAN:  # pragma: no cover - minimal stand-in
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401
+            """Minimal stub that accepts arbitrary arguments."""
+
+        def fit_predict(self, vectors):
+            return _np.zeros(len(vectors), dtype=int)
+
+    class _KMeans:  # pragma: no cover - minimal stand-in
+        def __init__(self, n_clusters=8, *args, **kwargs) -> None:  # noqa: D401
+            self.n_clusters = max(1, int(n_clusters))
+
+        def fit_predict(self, vectors):
+            n = len(vectors)
+            if n == 0:
+                return _np.array([], dtype=int)
+            return _np.arange(n, dtype=int) % self.n_clusters
+
+    def _normalize(vectors, norm="l2"):
+        arr = _np.array(vectors, dtype=float)
+        if arr.ndim == 1:
+            arr = arr.reshape(1, -1)
+        if norm != "l2":
+            raise ValueError("Only l2 norm is supported in the stub")
+        norms = _np.linalg.norm(arr, axis=1, keepdims=True)
+        norms[norms == 0.0] = 1.0
+        return arr / norms
+
+    cluster_stub.DBSCAN = _DBSCAN
+    cluster_stub.KMeans = _KMeans
+    preprocessing_stub.normalize = _normalize
+
+    sklearn_stub.cluster = cluster_stub
+    sklearn_stub.preprocessing = preprocessing_stub
+
+    sys.modules["sklearn"] = sklearn_stub
+    sys.modules["sklearn.cluster"] = cluster_stub
+    sys.modules["sklearn.preprocessing"] = preprocessing_stub
+
+
+def pytest_configure() -> None:
+    """Install compatibility stubs before pytest starts collecting tests."""
+
+    _ensure_openai_stub()
+    _ensure_qdrant_stub()
+    _ensure_tqdm_stub()
+    _ensure_sklearn_stub()
+

--- a/tests/test_categorize_helpers.py
+++ b/tests/test_categorize_helpers.py
@@ -1,0 +1,197 @@
+"""Unit tests for helper utilities in :mod:`GptCategorize.categorize`."""
+
+from __future__ import annotations
+
+import json
+import math
+from datetime import datetime, timezone
+
+import numpy as np
+import pytest
+
+from GptCategorize.categorize import (
+    Chat,
+    _detect_projectish,
+    _first_user_prompt,
+    cluster_text_cohesion,
+    cosine_to_euclid_eps,
+    extract_chats_from_json_blob,
+    load_chats_from_conversations_json,
+    temporal_cohesion,
+    to_epoch,
+)
+
+
+def test_to_epoch_parses_various_inputs() -> None:
+    """``to_epoch`` should gracefully parse diverse timestamp formats."""
+
+    assert to_epoch(None) is None
+    assert to_epoch(42) == pytest.approx(42.0)
+
+    millis = 1_700_000_000_000
+    assert to_epoch(millis) == pytest.approx(1_700_000_000.0)
+
+    iso_text = "2024-01-01T12:34:56Z"
+    expected = datetime(2024, 1, 1, 12, 34, 56, tzinfo=timezone.utc).timestamp()
+    assert to_epoch(iso_text) == pytest.approx(expected)
+
+    assert to_epoch("not-a-timestamp") is None
+
+
+def test_detect_projectish_scans_nested_fields() -> None:
+    """Project information is detected from direct and nested keys."""
+
+    obj = {
+        "metadata": {"folder_id": "folder-123"},
+        "conversation": {"project": 7},
+    }
+    assert _detect_projectish(obj) == "folder-123"
+
+    assert _detect_projectish({"conversation": {"project": 7}}) == "7"
+    assert _detect_projectish({}) is None
+
+
+def test_first_user_prompt_prefers_oldest_and_truncates() -> None:
+    """The first user prompt should pick the earliest user message."""
+
+    conversation = {
+        "messages": [
+            {
+                "author": {"role": "assistant"},
+                "content": {"parts": ["Assistant reply"]},
+                "create_time": 150,
+            },
+            {
+                "author": {"role": "user"},
+                "content": {"parts": ["Later user message to ignore"]},
+                "create_time": 200,
+            },
+        ],
+        "mapping": {
+            "node": {
+                "message": {
+                    "author": {"role": "user"},
+                    "content": {
+                        "parts": [
+                            "Earliest user message with enough words to truncate",
+                        ]
+                    },
+                    "create_time": "1970-01-01T00:00:50Z",
+                }
+            }
+        },
+    }
+
+    result = _first_user_prompt(conversation, max_words=5)
+    assert result == "Earliest user message with enough"
+
+
+def test_extract_chats_from_json_blob_converts_nested_structures() -> None:
+    """Conversations are detected whether direct or wrapped in another object."""
+
+    data = [
+        {
+            "id": "chat-1",
+            "title": "Direct Chat",
+            "create_time": 1_700_000_000,
+            "update_time": 1_700_000_360,
+            "messages": [
+                {
+                    "author": {"role": "user"},
+                    "content": {"parts": ["Hello direct chat prompt"]},
+                }
+            ],
+            "metadata": {"workspace_id": "workspace-123"},
+        },
+        {
+            "wrapper": {
+                "title": "Nested Chat",
+                "id": "chat-2",
+                "messages": [
+                    {
+                        "author": {"role": "user"},
+                        "content": {"parts": ["Nested user prompt"]},
+                    }
+                ],
+                "created_at": "2024-01-02T00:00:00Z",
+                "updated_at": "2024-01-02T01:00:00Z",
+                "metadata": {"project": "proj-xyz"},
+            }
+        },
+    ]
+
+    chats = extract_chats_from_json_blob(data)
+    assert {chat.id for chat in chats} == {"chat-1", "chat-2"}
+
+    direct = next(chat for chat in chats if chat.id == "chat-1")
+    assert direct.title == "Direct Chat"
+    assert direct.project_id == "workspace-123"
+    assert direct.prompt_excerpt == "Hello direct chat prompt"
+    assert direct.create_time == pytest.approx(1_700_000_000.0)
+
+    nested = next(chat for chat in chats if chat.id == "chat-2")
+    assert nested.title == "Nested Chat"
+    assert nested.project_id == "proj-xyz"
+    assert nested.prompt_excerpt == "Nested user prompt"
+    expected_ct = datetime(2024, 1, 2, tzinfo=timezone.utc).timestamp()
+    assert nested.create_time == pytest.approx(expected_ct)
+
+
+def test_load_chats_from_conversations_json_deduplicates_latest(tmp_path) -> None:
+    """NDJSON inputs should be parsed and deduplicated by ``id``."""
+
+    first = {
+        "id": "chat-1",
+        "title": "Old Title",
+        "update_time": 1_700_000_000,
+    }
+    second = {
+        "id": "chat-1",
+        "title": "New Title",
+        "update_time": 1_700_000_500,
+    }
+
+    path = tmp_path / "conversations.ndjson"
+    path.write_text("\n".join(json.dumps(item) for item in (first, second)))
+
+    chats = load_chats_from_conversations_json(str(path))
+
+    assert len(chats) == 1
+    chat = chats[0]
+    assert chat.title == "New Title"
+    assert chat.update_time == pytest.approx(1_700_000_500.0)
+
+
+def test_cluster_text_cohesion_returns_average_similarity() -> None:
+    """Cohesion is the average cosine similarity between cluster members."""
+
+    vectors = np.array([[1.0, 1.0], [2.0, 2.0], [1.0, 0.0]])
+    labels = np.array([0, 0, 1])
+
+    assert cluster_text_cohesion(vectors, labels, 0) == pytest.approx(1.0)
+    assert cluster_text_cohesion(vectors, labels, 1) == 0.0
+
+
+def test_temporal_cohesion_computes_average_similarity() -> None:
+    """Temporal cohesion averages the exponential kernel across pairs."""
+
+    base = 1_700_000_000
+    members = [
+        Chat(id="a", title="A", create_time=base),
+        Chat(id="b", title="B", create_time=base + 86_400),
+        Chat(id="c", title="C", create_time=base + 2 * 86_400),
+    ]
+
+    expected = (2 * math.exp(-1 / 30) + math.exp(-2 / 30)) / 3
+    assert temporal_cohesion(members, time_decay_days=30.0) == pytest.approx(expected)
+
+    missing_times = [Chat(id="x", title="X"), Chat(id="y", title="Y")]
+    assert temporal_cohesion(missing_times) == 0.5
+
+
+def test_cosine_to_euclid_eps_handles_negative_values() -> None:
+    """Cosine epsilons are clamped to non-negative values before conversion."""
+
+    assert cosine_to_euclid_eps(-0.5) == 0.0
+    assert cosine_to_euclid_eps(0.5) == pytest.approx(math.sqrt(1.0))
+


### PR DESCRIPTION
## Summary
- add pytest-cov and pytest-xdist dev dependencies to support coverage reporting and parallel execution
- update the Makefile test target to exercise pytest with coverage and xdist
- introduce lightweight stubs for optional integrations and add unit tests that cover key helper utilities in `GptCategorize.categorize`

## Testing
- pytest -n auto --cov=GptCategorize --cov=main --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68c9e51da838832dbab7b444b29d8aff