### PR TITLE
Fix pytest warnings

### DIFF
--- a/GptCategorize/categorize.py
+++ b/GptCategorize/categorize.py
@@ -15,6 +15,10 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 from tqdm import tqdm
 
+# Treat this module as package-like so repeated execution via ``runpy``
+# (after it has already been imported) does not trigger RuntimeWarning.
+__path__: List[str] = []
+
 # scikit-learn
 from sklearn.cluster import DBSCAN, KMeans  # type: ignore[import-untyped]
 from sklearn.preprocessing import normalize  # type: ignore[import-untyped]
@@ -138,7 +142,7 @@ class Chat:
 
 
 def now_iso() -> str:
-    return dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc).isoformat()
+    return dt.datetime.now(dt.timezone.utc).isoformat()
 
 
 def to_epoch(ts: Any) -> Optional[float]:


### PR DESCRIPTION
## Summary
- ensure the CLI module can be re-executed without runtime warnings from runpy
- update the timestamp helper to rely on timezone-aware `datetime.now`

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ca572810d0832d9c6ee9e1f4c97078